### PR TITLE
storage/postgres: store and retrieve sample labels

### DIFF
--- a/internal/pprof/label.go
+++ b/internal/pprof/label.go
@@ -1,29 +1,10 @@
 package pprof
 
-import "context"
-
-type label struct {
-	key   string
-	value string
+type Label struct {
+	Key      string
+	ValueStr string
+	ValueNum int64
 }
 
 // LabelSet is a set of labels.
-type LabelSet struct {
-	list []label
-}
-
-// labelContextKey is the type of contextKeys used for profiler labels.
-type labelContextKey struct{}
-
-func labelValue(ctx context.Context) labelMap {
-	labels, _ := ctx.Value(labelContextKey{}).(*labelMap)
-	if labels == nil {
-		return labelMap(nil)
-	}
-	return *labels
-}
-
-// labelMap is the representation of the label set held in the context type.
-// This is an initial implementation, but it will be replaced with something
-// that admits incremental immutable modification more efficiently.
-type labelMap map[string]string
+type LabelSet []Label

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -11,7 +11,6 @@ type Digest string
 type Profile struct {
 	Type       ProfileType
 	CreatedAt  time.Time
-	ReceivedAt time.Time
 	Service    *Service
 }
 

--- a/pkg/profile/repository.go
+++ b/pkg/profile/repository.go
@@ -45,9 +45,8 @@ func (req *CreateProfileRequest) Validate() error {
 func (repo *Repository) CreateProfile(ctx context.Context, req *CreateProfileRequest) (token string, err error) {
 	service := NewService(req.Service, req.ID, req.Labels)
 	prof := &Profile{
-		CreatedAt:  time.Now().UTC(),
-		ReceivedAt: time.Now().UTC(),
-		Service:    service,
+		CreatedAt: time.Now().UTC(),
+		Service:   service,
 	}
 
 	if err := repo.storage.Create(ctx, prof); err != nil {
@@ -84,8 +83,7 @@ func (req *UpdateProfileRequest) Validate() error {
 
 func (repo *Repository) UpdateProfile(ctx context.Context, req *UpdateProfileRequest, r io.Reader) error {
 	prof := &Profile{
-		Type:       req.Type,
-		ReceivedAt: time.Now().UTC(),
+		Type: req.Type,
 		Service: &Service{
 			BuildID: req.ID,
 			Token:   TokenFromString(req.Token),

--- a/pkg/storage/postgres/labels.go
+++ b/pkg/storage/postgres/labels.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+)
+
+type sampleLabel struct {
+	Key      string `json:"key"`
+	ValueStr string `json:"value_str,omitempty"`
+	ValueNum int64  `json:"value_num,omitempty"`
+}
+
+type sampleLabels []sampleLabel
+
+var (
+	_ sql.Scanner   = (sampleLabels)(nil)
+	_ driver.Valuer = (sampleLabels)(nil)
+)
+
+func (sl sampleLabels) Scan(src interface{}) error {
+	if src == nil {
+		return nil
+	}
+	return json.Unmarshal(src.([]byte), &sl)
+}
+
+func (sl sampleLabels) Value() (driver.Value, error) {
+	if sl == nil {
+		return nil, nil
+	}
+	return json.Marshal(sl)
+}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -45,24 +45,25 @@ func (st *pqStorage) Create(ctx context.Context, prof *profile.Profile) error {
 }
 
 func (st *pqStorage) Update(ctx context.Context, prof *profile.Profile, r io.Reader) error {
-	pprof, err := pprofProfile.Parse(r)
+	pp, err := pprofProfile.Parse(r)
 	if err != nil {
 		return fmt.Errorf("could not parse profile: %v", err)
 	}
 
-	return st.updateProfile(ctx, prof, pprof)
+	return st.updateProfile(ctx, prof, pp)
 }
 
-func (st *pqStorage) updateProfile(ctx context.Context, prof *profile.Profile, pprof *pprofProfile.Profile) error {
-	var sqlInsertSamples string
+func (st *pqStorage) updateProfile(ctx context.Context, prof *profile.Profile, pp *pprofProfile.Profile) error {
+	var sqlSamples sqlSamplesBuilder
 	switch prof.Type {
 	case profile.CPUProfile:
-		sqlInsertSamples = sqlSamplesCPU.InsertQuery()
+		sqlSamples = sqlSamplesCPU
 	case profile.HeapProfile:
-		sqlInsertSamples = sqlSamplesHeap.InsertQuery()
+		sqlSamples = sqlSamplesHeap
 	default:
 		return fmt.Errorf("profile type %v is not supported", prof.Type)
 	}
+	_ = sqlSamples
 
 	defer func(t time.Time) {
 		st.logger.Debugw("update profile", "time", time.Since(t))
@@ -84,7 +85,7 @@ func (st *pqStorage) updateProfile(ctx context.Context, prof *profile.Profile, p
 		return fmt.Errorf("could not prepare COPY statement %q: %v", sqlCopyTable, err)
 	}
 
-	err = st.copyProfSamples(ctx, copyStmt, pprof.Sample)
+	err = st.copyProfSamples(ctx, copyStmt, pp.Sample)
 	if err != nil {
 		return err
 	}
@@ -94,17 +95,16 @@ func (st *pqStorage) updateProfile(ctx context.Context, prof *profile.Profile, p
 		return fmt.Errorf("could not insert locations: %v", err)
 	}
 
-	insertSamplesStmt, err := tx.PrepareContext(ctx, sqlInsertSamples)
+	insertSamplesStmt, err := tx.PrepareContext(ctx, sqlSamples.BuildInsertQuery())
 	if err != nil {
-		return fmt.Errorf("could not prepare INSERT statement %q: %v", sqlInsertSamples, err)
+		return fmt.Errorf("could not prepare INSERT statement: %v", err)
 	}
 
 	_, err = insertSamplesStmt.ExecContext(
 		ctx,
 		prof.Service.BuildID,
 		prof.Service.Token.String(),
-		time.Unix(0, pprof.TimeNanos),
-		prof.ReceivedAt,
+		time.Unix(0, pp.TimeNanos),
 	)
 	if err != nil {
 		return fmt.Errorf("could not insert samples: %v", err)
@@ -131,6 +131,8 @@ func (st *pqStorage) copyProfSamples(ctx context.Context, stmt *sql.Stmt, sample
 	}(time.Now())
 
 	for sampleID, sample := range samples {
+		labels := st.getSampleLabels(sample)
+
 		for _, loc := range sample.Location {
 			for _, ln := range loc.Line {
 				_, err := stmt.ExecContext(
@@ -139,7 +141,8 @@ func (st *pqStorage) copyProfSamples(ctx context.Context, stmt *sql.Stmt, sample
 					ln.Function.Name,
 					ln.Function.Filename,
 					ln.Line,
-					pq.Array(sample.Value),
+					pq.Int64Array(sample.Value),
+					labels,
 				)
 				if err != nil {
 					return fmt.Errorf("could not exec COPY statement: %v", err)
@@ -154,17 +157,28 @@ func (st *pqStorage) copyProfSamples(ctx context.Context, stmt *sql.Stmt, sample
 	return err
 }
 
+// returns at most one label for a key
+func (st *pqStorage) getSampleLabels(sample *pprofProfile.Sample) (labels sampleLabels) {
+	for k, v := range sample.Label {
+		labels = append(labels, sampleLabel{Key: k, ValueStr: v[0]})
+	}
+	for k, v := range sample.NumLabel {
+		labels = append(labels, sampleLabel{Key: k, ValueNum: v[0]})
+	}
+	return labels
+}
+
 func (st *pqStorage) Query(ctx context.Context, queryReq *profile.QueryRequest) (io.Reader, error) {
 	return st.queryByCreatedAt(ctx, queryReq)
 }
 
 func (st *pqStorage) queryByCreatedAt(ctx context.Context, queryReq *profile.QueryRequest) (io.Reader, error) {
-	var sqlSelectSamples string
+	var sqlSamples sqlSamplesBuilder
 	switch queryReq.Type {
 	case profile.CPUProfile:
-		sqlSelectSamples = sqlSamplesCPU.SelectQuery()
+		sqlSamples = sqlSamplesCPU
 	case profile.HeapProfile:
-		sqlSelectSamples = sqlSamplesHeap.SelectQuery()
+		sqlSamples = sqlSamplesHeap
 	default:
 		return nil, fmt.Errorf("profile type %v is not supported", queryReq.Type)
 	}
@@ -181,7 +195,7 @@ func (st *pqStorage) queryByCreatedAt(ctx context.Context, queryReq *profile.Que
 		whereLabels += fmt.Sprintf(" AND v.labels->'%s' = $%d", label.Key, len(args))
 	}
 
-	query := fmt.Sprintf(sqlSelectSamples, whereLabels)
+	query := sqlSamples.BuildSelectQuery(whereLabels)
 	selectSamplesStmt, err := st.db.PrepareContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("could not prepare SELECT samples statement: %v", err)
@@ -196,22 +210,24 @@ func (st *pqStorage) queryByCreatedAt(ctx context.Context, queryReq *profile.Que
 	locSet := make(map[int64]struct{})
 	var locs pq.Int64Array
 
-	var p []pprof.Runtime_MemProfileRecord
+	var p []pprof.MemProfileRecord
 	for samplesRows.Next() {
-		r := pprof.Runtime_MemProfileRecord{}
+		r := pprof.MemProfileRecord{}
+		var labels sampleLabels
 		locs = locs[:0]
-		err := samplesRows.Scan(&r.AllocObjects, &r.AllocBytes, &r.InUseObjects, &r.InUseBytes, &locs)
+		err := samplesRows.Scan(&r.AllocObjects, &r.AllocBytes, &r.InUseObjects, &r.InUseBytes, &locs, &labels)
 		if err != nil {
 			return nil, err
 		}
-		if len(locs) > len(r.Stack0) {
-			// TODO(narqo): figure out how this happens
-			//st.logger.Debugf("locations: %v", locs)
-			locs = locs[:len(r.Stack0)]
+		for _, loc := range locs {
+			r.Stack0 = append(r.Stack0, uint64(loc))
+			locSet[loc] = struct{}{}
 		}
-		for i, addr := range locs {
-			r.Stack0[i] = uint64(addr)
-			locSet[addr] = struct{}{}
+		for _, label := range labels {
+			if label.Key == "" {
+				continue
+			}
+			r.Labels = append(r.Labels, pprof.Label(label))
 		}
 		p = append(p, r)
 	}
@@ -227,8 +243,8 @@ func (st *pqStorage) queryByCreatedAt(ctx context.Context, queryReq *profile.Que
 	if err != nil {
 		return nil, fmt.Errorf("could not prepare SELECT locations statement: %v", err)
 	}
-	for addr := range locSet {
-		locs = append(locs, addr)
+	for loc := range locSet {
+		locs = append(locs, loc)
 	}
 
 	locRows, err := selectLocsStmt.QueryContext(ctx, locs)

--- a/pkg/storage/postgres/sql.go
+++ b/pkg/storage/postgres/sql.go
@@ -13,36 +13,45 @@ const (
 		VALUES ($1, $2, $3, $4, $5)`
 
 	sqlCreateTempTable = `
-		CREATE TEMPORARY TABLE IF NOT EXISTS pprof_samples_tmp (sample_id INT, func_name TEXT, file_name TEXT, line INT, values_all BIGINT[]) 
+		CREATE TEMPORARY TABLE IF NOT EXISTS pprof_samples_tmp (
+			sample_id INT,
+			func_name TEXT,
+			file_name TEXT,
+			line INT,
+			values_all BIGINT[],
+			labels jsonb
+		)
 		ON COMMIT DELETE ROWS;`
 
 	sqlInsertLocations = `
-		INSERT INTO pprof_locations (func_name, file_name, line) 
-		SELECT tmp.func_name, tmp.file_name, tmp.line 
+		INSERT INTO pprof_locations (func_name, file_name, line)
+		SELECT tmp.func_name, tmp.file_name, tmp.line
 		FROM pprof_samples_tmp tmp 
-		LEFT JOIN pprof_locations l 
+		LEFT JOIN pprof_locations l
 		ON tmp.func_name = l.func_name AND tmp.file_name = l.file_name AND tmp.line = l.line
 		WHERE l.func_name IS NULL
 		ON CONFLICT (func_name, file_name, line) DO NOTHING;`
 
 	sqlInsertSamplesTmpl = `
-		INSERT INTO %[1]s (build_id, token, created_at, received_at, locations, %[2]s)
-		SELECT s.build_id, s.token, s.created_at, s.received_at, locations, %[2]s
-		FROM (values ($1, $2, $3::timestamp, $4::timestamp)) AS s (build_id, token, created_at, received_at),
+		INSERT INTO %[1]s (build_id, token, created_at, locations, labels, %[2]s)
+		SELECT s.build_id, s.token, s.created_at, locations, labels, %[2]s
+		FROM (values ($1, $2, $3::timestamp)) AS s (build_id, token, created_at),
 	  	(
-			SELECT sample_id, array_agg(l.location_id) as locations, %[3]s
+			SELECT sample_id, array_agg(l.location_id) as locations, labels, %[3]s
 			FROM pprof_samples_tmp tmp
-			INNER JOIN pprof_locations l 
+			INNER JOIN pprof_locations l
 			ON tmp.func_name = l.func_name AND tmp.file_name = l.file_name AND tmp.line = l.line
-			GROUP BY sample_id, %[2]s
-		) AS t;`
+			GROUP BY sample_id, labels, %[2]s
+		) AS t1;`
 
 	sqlSelectLocations = `
-		SELECT l.location_id, l.func_name, l.file_name, l.line FROM pprof_locations l
+		SELECT l.location_id, l.func_name, l.file_name, l.line 
+		FROM pprof_locations l
 		WHERE l.location_id = any($1);`
 
 	sqlSelectSamplesTmpl = `
-		SELECT %[2]s, s.locations FROM %[1]s s, services v
+		SELECT %[2]s, s.locations, s.labels 
+		FROM %[1]s s, services v
 		WHERE s.build_id = v.build_id AND s.token = v.token and v.name = $1 
 		%%[1]s
 		AND s.created_at BETWEEN $2 AND $3
@@ -57,6 +66,7 @@ var (
 		"file_name",
 		"line",
 		"values_all",
+		"labels",
 	)
 	sqlSamplesCPU = newSQLSamplesBuilder(
 		"pprof_samples_cpu",
@@ -91,12 +101,12 @@ func newSQLSamplesBuilder(table string, cols ...string) sqlSamplesBuilder {
 	return s
 }
 
-func (s sqlSamplesBuilder) InsertQuery() string {
+func (s sqlSamplesBuilder) BuildInsertQuery() string {
 	return s.insertQuery
 }
 
-func (s sqlSamplesBuilder) SelectQuery() string {
-	return s.selectQuery
+func (s sqlSamplesBuilder) BuildSelectQuery(args ...interface{}) string {
+	return fmt.Sprintf(s.selectQuery, args...)
 }
 
 func createInsertSamples(table string, cols ...string) string {

--- a/pkg/storage/postgres/sql/init.sql
+++ b/pkg/storage/postgres/sql/init.sql
@@ -18,11 +18,10 @@ CREATE TABLE pprof_samples_cpu (
   build_id      VARCHAR(40) NOT NULL,
   token         VARCHAR(40) NOT NULL,
   created_at    TIMESTAMPTZ NOT NULL,
-  received_at   TIMESTAMPTZ NOT NULL,
   locations     INTEGER[],
   samples_count BIGINT,
   cpu_nanos     BIGINT,
-  labels        INTEGER[],
+  labels        jsonb,
 
   FOREIGN KEY (build_id, token) REFERENCES services ON DELETE CASCADE
 );
@@ -35,13 +34,12 @@ CREATE TABLE pprof_samples_heap (
   build_id      VARCHAR(40) NOT NULL,
   token         VARCHAR(40) NOT NULL,
   created_at    TIMESTAMPTZ NOT NULL,
-  received_at   TIMESTAMPTZ NOT NULL,
   locations     INTEGER[],
   alloc_objects BIGINT,
   alloc_bytes   BIGINT,
   inuse_objects BIGINT,
   inuse_bytes   BIGINT,
-  labels        INTEGER[],
+  labels        jsonb,
 
   FOREIGN KEY (build_id, token) REFERENCES services ON DELETE CASCADE
 );
@@ -60,14 +58,3 @@ CREATE TABLE pprof_locations (
 );
 
 CREATE INDEX ON pprof_locations (func_name, file_name, line);
-
-DROP TABLE IF EXISTS pprof_labels;
-
-CREATE TABLE pprof_labels (
-  label_id  SERIAL PRIMARY KEY,
-  key       TEXT NOT NULL,
-  value_str TEXT,
-  value_num INTEGER,
-
-  UNIQUE (key, value_str, value_num)
-);


### PR DESCRIPTION
Plus
 
- get rid of `received_at` column; it wasn't used anyway, so we can save some storage space
- fix typo in heap profile builder