### PR TITLE
agent: send supported profiles

### DIFF
--- a/agent/options.go
+++ b/agent/options.go
@@ -20,11 +20,18 @@ func WithHeapProfile() Option {
 	}
 }
 
-func WithMuxProfile() Option {
-	return func(a *agent) {
-		a.MuxProfile = true
-	}
-}
+// TODO(narqo): support the rest of profile types
+//func WithBlockProfile() Option {
+//	return func(a *agent) {
+//		a.BlockProfile = true
+//	}
+//}
+//
+//func WithMuxProfile() Option {
+//	return func(a *agent) {
+//		a.MuxProfile = true
+//	}
+//}
 
 func WithCollector(addr string) Option {
 	return func(a *agent) {


### PR DESCRIPTION
- CPU profiling enabled by default
- only heap and CPU profiling support by server; disable the rest in agent
- dis-align initial profiling by adding extra N seconds of sleep