### PR TITLE
pkg/storage: update ProfileList iterator API

### DIFF
--- a/pkg/profefe/profiles_handler.go
+++ b/pkg/profefe/profiles_handler.go
@@ -35,7 +35,7 @@ func (h *ProfilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if urlPath == apiProfilesMergePath {
-		handler = h.HandleFindProfile
+		handler = h.HandleMergeProfile
 	} else if urlPath == apiProfilesPath {
 		switch r.Method {
 		case http.MethodPost:
@@ -116,7 +116,7 @@ func (h *ProfilesHandler) HandleFindProfiles(w http.ResponseWriter, r *http.Requ
 	return nil
 }
 
-func (h *ProfilesHandler) HandleFindProfile(w http.ResponseWriter, r *http.Request) error {
+func (h *ProfilesHandler) HandleMergeProfile(w http.ResponseWriter, r *http.Request) error {
 	params := &storage.FindProfilesParams{}
 	if err := parseFindProfileParams(params, r); err != nil {
 		return err
@@ -125,7 +125,7 @@ func (h *ProfilesHandler) HandleFindProfile(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, params.Type))
 
-	err := h.querier.FindProfileTo(r.Context(), w, params)
+	err := h.querier.FindMergeProfileTo(r.Context(), w, params)
 	if err == storage.ErrNotFound {
 		return StatusError(http.StatusNotFound, "nothing found", nil)
 	} else if err == storage.ErrEmpty {

--- a/pkg/profefe/querier.go
+++ b/pkg/profefe/querier.go
@@ -30,18 +30,17 @@ func (q *Querier) GetProfile(ctx context.Context, pid profile.ID) (*pprofProfile
 	}
 	defer list.Close()
 
-	pp, err := list.Next()
-	if err == io.EOF {
+	if !list.Next() {
 		return nil, storage.ErrNotFound
 	}
-	return pp, err
+	return list.Profile()
 }
 
 func (q *Querier) FindProfiles(ctx context.Context, params *storage.FindProfilesParams) ([]*profile.Meta, error) {
 	return q.sr.FindProfiles(ctx, params)
 }
 
-func (q *Querier) FindProfileTo(ctx context.Context, dst io.Writer, params *storage.FindProfilesParams) error {
+func (q *Querier) FindMergeProfileTo(ctx context.Context, dst io.Writer, params *storage.FindProfilesParams) error {
 	pids, err := q.sr.FindProfileIDs(ctx, params)
 	if err != nil {
 		return err
@@ -56,11 +55,8 @@ func (q *Querier) FindProfileTo(ctx context.Context, dst io.Writer, params *stor
 	defer list.Close()
 
 	pps := make([]*pprofProfile.Profile, 0, len(pids))
-	for {
-		p, err := list.Next()
-		if err == io.EOF {
-			break
-		}
+	for list.Next() {
+		p, err := list.Profile()
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/badger/integration_test.go
+++ b/pkg/storage/badger/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -55,13 +54,13 @@ func TestStorage_WriteFind(t *testing.T) {
 	list, err := st.ListProfiles(context.Background(), []profile.ID{found[0].ProfileID})
 	require.NoError(t, err)
 
-	gotpp, err := list.Next()
+	require.True(t, list.Next())
+	gotpp, err := list.Profile()
 	require.NoError(t, err)
 
 	assert.True(t, pprofutil.ProfilesEqual(pp, gotpp))
 
-	_, err = list.Next()
-	assert.Equal(t, io.EOF, err)
+	require.False(t, list.Next())
 
 	assert.NoError(t, list.Close())
 }
@@ -235,11 +234,8 @@ func TestStorage_ListProfiles_MultipleResults(t *testing.T) {
 		defer list.Close()
 
 		var found int
-		for {
-			gotpp, err := list.Next()
-			if err == io.EOF {
-				break
-			}
+		for list.Next() {
+			gotpp, err := list.Profile()
 			require.NoError(t, err)
 
 			found++

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -45,15 +45,16 @@ func (params *FindProfilesParams) Validate() error {
 		return xerrors.Errorf("unknown profile type %s", params.Type)
 	}
 	if params.CreatedAtMin.IsZero() || params.CreatedAtMax.IsZero() {
-		return xerrors.Errorf("createdAt time zero: min %v, max %v", params.CreatedAtMin, params.CreatedAtMax)
+		return xerrors.Errorf("profile created time zero: min %v, max %v", params.CreatedAtMin, params.CreatedAtMax)
 	}
 	if params.CreatedAtMin.After(params.CreatedAtMax) {
-		return xerrors.Errorf("createdAt time min after max: min %v, max %v", params.CreatedAtMin, params.CreatedAtMax)
+		return xerrors.Errorf("profile created time min after max: min %v, max %v", params.CreatedAtMin, params.CreatedAtMax)
 	}
 	return nil
 }
 
 type ProfileList interface {
-	Next() (*pprofProfile.Profile, error)
+	Next() bool
+	Profile() (*pprofProfile.Profile, error)
 	Close() error
 }


### PR DESCRIPTION
Get rid of `io.EOF`, which felt awkward. Make the API more like a conventional iterator in Go. I.e.

```go
list := getProfilesList()
defer list.Close()

for list.Next() {
  p, err := list.Profile()
}
```

Also, have adjusted naming in internal methods.