### PR TITLE
Respond with profile data on creation

### DIFF
--- a/pkg/profefe/collector.go
+++ b/pkg/profefe/collector.go
@@ -23,8 +23,12 @@ func NewCollector(logger *log.Logger, sw storage.Writer) *Collector {
 	}
 }
 
-func (c *Collector) CollectProfileFrom(ctx context.Context, src io.Reader, req *WriteProfileRequest) error {
-	return c.sw.WriteProfile(ctx, req.NewProfileMeta(), src)
+func (c *Collector) CollectProfileFrom(ctx context.Context, src io.Reader, req *WriteProfileRequest) (Profile, error) {
+	meta := req.NewProfileMeta()
+	if err := c.sw.WriteProfile(ctx, meta, src); err != nil {
+		return Profile{}, err
+	}
+	return ProfileFromProfileMeta(meta), nil
 }
 
 type WriteProfileRequest struct {
@@ -83,6 +87,6 @@ func (req *WriteProfileRequest) Validate() error {
 	return nil
 }
 
-func (req *WriteProfileRequest) NewProfileMeta() *profile.Meta {
+func (req *WriteProfileRequest) NewProfileMeta() profile.Meta {
 	return profile.NewProfileMeta(req.Service, req.Type, req.InstanceID, req.Labels)
 }

--- a/pkg/profefe/profile.go
+++ b/pkg/profefe/profile.go
@@ -1,0 +1,26 @@
+package profefe
+
+import (
+	"time"
+
+	"github.com/profefe/profefe/pkg/profile"
+)
+
+// Profile is the JSON representation of a profile returned with API response.
+type Profile struct {
+	ProfileID profile.ID     `json:"id"`
+	Type      string         `json:"type"`
+	Service   string         `json:"service"`
+	Labels    profile.Labels `json:"labels,omitempty"`
+	CreatedAt time.Time      `json:"created_at,omitempty"`
+}
+
+func ProfileFromProfileMeta(meta profile.Meta) Profile {
+	return Profile{
+		ProfileID: meta.ProfileID,
+		Type:      meta.Type.String(),
+		Service:   meta.Service,
+		Labels:    meta.Labels,
+		CreatedAt: meta.CreatedAt,
+	}
+}

--- a/pkg/profefe/profiles_handler.go
+++ b/pkg/profefe/profiles_handler.go
@@ -62,12 +62,12 @@ func (h *ProfilesHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Req
 		return StatusError(http.StatusBadRequest, fmt.Sprintf("bad request: %v", err), nil)
 	}
 
-	err := h.collector.CollectProfileFrom(r.Context(), r.Body, req)
+	profModel, err := h.collector.CollectProfileFrom(r.Context(), r.Body, req)
 	if err != nil {
 		return StatusError(http.StatusInternalServerError, "failed to create profile", err)
 	}
 
-	ReplyOK(w)
+	ReplyJSON(w, profModel)
 
 	return nil
 }
@@ -104,14 +104,16 @@ func (h *ProfilesHandler) HandleFindProfiles(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 
-	metas, err := h.querier.FindProfiles(r.Context(), params)
+	profModels, err := h.querier.FindProfiles(r.Context(), params)
 	if err == storage.ErrNotFound {
 		return StatusError(http.StatusNotFound, "nothing found", nil)
 	} else if err == storage.ErrEmpty {
 		return StatusError(http.StatusNoContent, "profile empty", nil)
+	} else if err != nil {
+		return err
 	}
 
-	ReplyJSON(w, metas)
+	ReplyJSON(w, profModels)
 
 	return nil
 }

--- a/pkg/profefe/querier.go
+++ b/pkg/profefe/querier.go
@@ -36,8 +36,17 @@ func (q *Querier) GetProfile(ctx context.Context, pid profile.ID) (*pprofProfile
 	return list.Profile()
 }
 
-func (q *Querier) FindProfiles(ctx context.Context, params *storage.FindProfilesParams) ([]*profile.Meta, error) {
-	return q.sr.FindProfiles(ctx, params)
+func (q *Querier) FindProfiles(ctx context.Context, params *storage.FindProfilesParams) ([]Profile, error) {
+	metas, err := q.sr.FindProfiles(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	profModels := make([]Profile, 0, len(metas))
+	for _, meta := range metas {
+		profModels = append(profModels, ProfileFromProfileMeta(meta))
+	}
+	return profModels, nil
 }
 
 func (q *Querier) FindMergeProfileTo(ctx context.Context, dst io.Writer, params *storage.FindProfilesParams) error {

--- a/pkg/profefe/reply_test.go
+++ b/pkg/profefe/reply_test.go
@@ -13,6 +13,22 @@ import (
 	"golang.org/x/xerrors"
 )
 
+func TestReplyJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	body := map[string]interface{}{"foo": "bar"}
+
+	ReplyJSON(w, body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("content-type"))
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.EqualValues(t, http.StatusOK, resp["code"])
+	assert.Equal(t, body, resp["body"])
+}
+
 func TestReplyError(t *testing.T) {
 	testRawErr := errors.New("unexpected error")
 
@@ -32,12 +48,12 @@ func TestReplyError(t *testing.T) {
 			"bad request",
 		},
 		{
-			xerrors.Errorf("unexpted error: %w", StatusError(http.StatusBadRequest, "bad request", nil)),
+			xerrors.Errorf("unexpected error: %w", StatusError(http.StatusBadRequest, "bad request", nil)),
 			http.StatusBadRequest,
 			"bad request",
 		},
 		{
-			xerrors.Errorf("unexpted error: %w", testRawErr),
+			xerrors.Errorf("unexpected error: %w", testRawErr),
 			http.StatusInternalServerError,
 			"internal error",
 		},
@@ -54,11 +70,11 @@ func TestReplyError(t *testing.T) {
 	}
 
 	for n, tc := range cases {
-		t.Run(fmt.Sprintf("case %d", n), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case=%d", n), func(t *testing.T) {
 			w := httptest.NewRecorder()
 			ReplyError(w, tc.err)
-			require.Equal(t, tc.wantCode, w.Code)
 
+			require.Equal(t, tc.wantCode, w.Code)
 			assert.Equal(t, "application/json", w.Header().Get("content-type"))
 
 			var resp map[string]interface{}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -90,8 +90,8 @@ type Meta struct {
 	CreatedAt  time.Time   `json:"created_at,omitempty"`
 }
 
-func NewProfileMeta(service string, ptyp ProfileType, iid InstanceID, labels Labels) *Meta {
-	return &Meta{
+func NewProfileMeta(service string, ptyp ProfileType, iid InstanceID, labels Labels) Meta {
+	return Meta{
 		ProfileID:  NewID(),
 		Service:    service,
 		Type:       ptyp,

--- a/pkg/profile/profile_type.go
+++ b/pkg/profile/profile_type.go
@@ -2,7 +2,6 @@ package profile
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -18,24 +17,6 @@ const (
 
 	OtherProfile = 127
 )
-
-func (ptype ProfileType) MarshalString() (s string) {
-	return strconv.FormatInt(int64(ptype), 10)
-}
-
-func (ptype *ProfileType) UnmarshalString(s string) error {
-	pt, err := strconv.Atoi(s)
-	if err != nil {
-		return err
-	}
-	switch pt := ProfileType(pt); pt {
-	case CPUProfile, HeapProfile, BlockProfile, MutexProfile, GoroutineProfile, OtherProfile:
-		*ptype = pt
-	default:
-		*ptype = UnknownProfile
-	}
-	return nil
-}
 
 func (ptype *ProfileType) FromString(s string) error {
 	s = strings.TrimSpace(s)

--- a/pkg/profile/profile_type_test.go
+++ b/pkg/profile/profile_type_test.go
@@ -23,16 +23,3 @@ func TestProfileType_FromString(t *testing.T) {
 		assert.Equal(t, tc.want, pt)
 	}
 }
-
-func TestProfileType_MarshalUnmarshalString(t *testing.T) {
-	cases := []ProfileType{
-		CPUProfile,
-		UnknownProfile,
-	}
-
-	for _, want := range cases {
-		var got ProfileType
-		require.NoError(t, got.UnmarshalString(want.MarshalString()))
-		assert.Equalf(t, want, got, "type %v (%v)", want.String(), want.MarshalString())
-	}
-}

--- a/pkg/storage/badger/integration_test.go
+++ b/pkg/storage/badger/integration_test.go
@@ -26,7 +26,7 @@ func TestStorage_WriteFind(t *testing.T) {
 	defer teardown()
 
 	service := "test-service-1"
-	meta := &profile.Meta{
+	meta := profile.Meta{
 		ProfileID:  profile.NewID(),
 		Service:    service,
 		Type:       profile.CPUProfile,
@@ -74,7 +74,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	for n := 1; n <= 2; n++ {
 		fileName := fmt.Sprintf("../../../testdata/collector_cpu_%d.prof", n)
-		meta := &profile.Meta{
+		meta := profile.Meta{
 			ProfileID:  profile.NewID(),
 			Service:    service,
 			Type:       profile.CPUProfile,
@@ -89,7 +89,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		t,
 		st,
 		"../../../testdata/collector_cpu_3.prof",
-		&profile.Meta{
+		profile.Meta{
 			ProfileID:  profile.NewID(),
 			Service:    "another-service",
 			Type:       profile.CPUProfile,
@@ -103,7 +103,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		t,
 		st,
 		"../../../testdata/collector_heap_1.prof",
-		&profile.Meta{
+		profile.Meta{
 			ProfileID:  profile.NewID(),
 			Service:    service,
 			Type:       profile.HeapProfile,
@@ -117,7 +117,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		t,
 		st,
 		"../../../testdata/collector_heap_2.prof",
-		&profile.Meta{
+		profile.Meta{
 			ProfileID:  profile.NewID(),
 			Service:    service,
 			Type:       profile.HeapProfile,
@@ -212,7 +212,7 @@ func TestStorage_ListProfiles_MultipleResults(t *testing.T) {
 		pid := profile.NewID()
 		pids = append(pids, pid)
 		fileName := fmt.Sprintf("../../../testdata/collector_cpu_%d.prof", n)
-		meta := &profile.Meta{
+		meta := profile.Meta{
 			ProfileID:  pid,
 			Service:    service,
 			Type:       profile.CPUProfile,
@@ -249,7 +249,7 @@ func TestStorage_ListProfiles_MultipleResults(t *testing.T) {
 	})
 }
 
-func testWriteProfile(t testing.TB, st *badgerStorage.Storage, fileName string, meta *profile.Meta) []byte {
+func testWriteProfile(t testing.TB, st *badgerStorage.Storage, fileName string, meta profile.Meta) []byte {
 	data, err := ioutil.ReadFile(fileName)
 	require.NoError(t, err)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,11 +16,11 @@ var (
 )
 
 type Writer interface {
-	WriteProfile(ctx context.Context, meta *profile.Meta, r io.Reader) error
+	WriteProfile(ctx context.Context, meta profile.Meta, r io.Reader) error
 }
 
 type Reader interface {
-	FindProfiles(ctx context.Context, params *FindProfilesParams) ([]*profile.Meta, error)
+	FindProfiles(ctx context.Context, params *FindProfilesParams) ([]profile.Meta, error)
 	FindProfileIDs(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error)
 	ListProfiles(ctx context.Context, pid []profile.ID) (ProfileList, error)
 }


### PR DESCRIPTION
closes #41 

@gianarb Could you verify that it solves your use case?

```http
> POST /api/0/profiles?service=profefe&instance_id=imported-profile&type=cpu&labels=host=localhost,az=home

<
{
  "code": 200,
  "body": {
    "id": "bnfbubnbudgj1mo98i3g",
    "type": "cpu",
    "service": "profefe",
    "labels": [
      {
        "key": "az",
        "value": "home"
      },
      {
        "key": "host",
        "value": "localhost"
      }
    ],
    "created_at": "2019-11-27T18:23:42.334459Z"
  }
}
```

```http
> GET /api/0/profiles?service=profefe&type=cpu&from=2019-01-25T00:00:00&to=2019-11-30T00:00:00

<
{
  "code": 200,
  "body": [
    {
      "id": "bnfah9fbudgif8og0bmg",
      "type": "cpu",
      "service": "profefe",
      "labels": [
        {
          "key": "az",
          "value": "home"
        },
        {
          "key": "host",
          "value": "localhost"
        }
      ],
      "created_at": "2019-05-30T23:14:00.707996+02:00"
    },
    {
      "id": "bnfah0vbudgif8og0bm0",
      "type": "cpu",
      "service": "profefe",
      "labels": [
        {
          "key": "az",
          "value": "home"
        },
        {
          "key": "host",
          "value": "localhost"
        }
      ],
      "created_at": "2019-05-30T23:10:05.499312+02:00"
    }
  ]
}
```

```http
> GET /api/0/version

<
{
  "code": 200,
  "body": {
    "version": "git-a65eddd",
    "commit": "a65eddd",
    "build_time": "2019-11-27T18:23:18Z"
  }
}
```