### PR TITLE
agent: support for threadcreate profiles

### DIFF
--- a/agent/options.go
+++ b/agent/options.go
@@ -39,6 +39,12 @@ func WithGoroutineProfile() Option {
 	}
 }
 
+func WithThreadcreateProfile() Option {
+	return func(a *Agent) {
+		a.ThreadcreateProfile = true
+	}
+}
+
 func WithLabels(args ...string) Option {
 	if len(args)%2 != 0 {
 		panic("agent.WithLabels: uneven number of arguments, expected key-value pairs")

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -28,6 +28,7 @@ func main() {
 		agent.WithBlockProfile(),
 		agent.WithMutexProfile(),
 		agent.WithGoroutineProfile(),
+		agent.WithThreadcreateProfile(),
 		agent.WithLogger(agentLogger),
 		agent.WithLabels(
 			"region", "europe-west3",


### PR DESCRIPTION
Following #45 

The PR adds a new option to `profefe/agent` — `agent.WithThreadcreateProfile()` — that enables collecting "stack traces that led to the creation of new OS threads" (see https://golang.org/pkg/runtime/pprof/#Profile)