### PR TITLE
pkg/profile: get rid of instance_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ To start the example, in a separate terminal window run:
 After a brief period, the application will start sending CPU profiles to the collector:
 
 ```
-send profile: http://localhost:10100/api/0/profiles?instance_id=87cdc549c84507f24944793b1ddbdc34&labels=version%3D1.0.0&service=hotapp-service&type=cpu
-send profile: http://localhost:10100/api/0/profiles?instance_id=87cdc549c84507f24944793b1ddbdc34&labels=version%3D1.0.0&service=hotapp-service&type=cpu
-send profile: http://localhost:10100/api/0/profiles?instance_id=87cdc549c84507f24944793b1ddbdc34&labels=version%3D1.0.0&service=hotapp-service&type=cpu
+send profile: http://localhost:10100/api/0/profiles?service=hotapp-service&labels=version=1.0.0&type=cpu
+send profile: http://localhost:10100/api/0/profiles?service=hotapp-service&labels=version=1.0.0&type=cpu
+send profile: http://localhost:10100/api/0/profiles?service=hotapp-service&labels=version=1.0.0&type=cpu
 ```
 
 ### Querying Profiles
@@ -108,7 +108,7 @@ uploading service1-cpu-backend1-20190313-0948Z.prof...OK
 ### Save pprof data
 
 ```
-POST /api/0/profiles?service=<service>&instance_id=<iid>&type=[cpu|heap|...]&labels=<key=value,key=value>
+POST /api/0/profiles?service=<service>&type=[cpu|heap|...]&labels=<key=value,key=value>
 body pprof.pb.gz
 
 < 200 OK
@@ -124,7 +124,6 @@ body pprof.pb.gz
 ```
 
 - `service` — service name (string)
-- `instance_id` — an identifier of running instance (string) (*TODO: why do we still need instance_id?*)
 - `type` — profile type (cpu, heap, block, mutex, goroutine, threadcreate or other)
 - `labels` — a set of key-value pairs, e.g. "region=europe-west3,dc=fra,ip=1.2.3.4,version=1.0" (Optional)
 

--- a/pkg/profefe/collector.go
+++ b/pkg/profefe/collector.go
@@ -32,10 +32,9 @@ func (c *Collector) CollectProfileFrom(ctx context.Context, src io.Reader, req *
 }
 
 type WriteProfileRequest struct {
-	Service    string
-	Type       profile.ProfileType
-	InstanceID profile.InstanceID
-	Labels     profile.Labels
+	Service string
+	Type    profile.ProfileType
+	Labels  profile.Labels
 }
 
 func (req *WriteProfileRequest) UnmarshalURL(q url.Values) error {
@@ -48,12 +47,6 @@ func (req *WriteProfileRequest) UnmarshalURL(q url.Values) error {
 		Type:    profile.UnknownProfile,
 		Labels:  nil,
 	}
-
-	iid, err := getInstanceID(q)
-	if err != nil {
-		return err
-	}
-	req.InstanceID = iid
 
 	ptype, err := getProfileType(q)
 	if err != nil {
@@ -78,9 +71,6 @@ func (req *WriteProfileRequest) Validate() error {
 	if req.Service == "" {
 		return xerrors.Errorf("service empty: req %v", req)
 	}
-	if req.InstanceID.IsNil() {
-		return xerrors.Errorf("instance_id empty: req: %v", req)
-	}
 	if req.Type == profile.UnknownProfile {
 		return xerrors.Errorf("unknown profile type %s: req %v", req.Type, req)
 	}
@@ -88,5 +78,5 @@ func (req *WriteProfileRequest) Validate() error {
 }
 
 func (req *WriteProfileRequest) NewProfileMeta() profile.Meta {
-	return profile.NewProfileMeta(req.Service, req.Type, req.InstanceID, req.Labels)
+	return profile.NewProfileMeta(req.Service, req.Type, req.Labels)
 }

--- a/pkg/profefe/request.go
+++ b/pkg/profefe/request.go
@@ -19,13 +19,6 @@ func getProfileType(q url.Values) (ptype profile.ProfileType, err error) {
 	return ptype, err
 }
 
-func getInstanceID(q url.Values) (iid profile.InstanceID, err error) {
-	if v := q.Get("instance_id"); v != "" {
-		return profile.InstanceID(v), nil
-	}
-	return iid, fmt.Errorf("bad request: bad instance id %q", q.Get("instance_id"))
-}
-
 func getLabels(q url.Values) (labels profile.Labels, err error) {
 	err = labels.FromString(q.Get("labels"))
 	return labels, err

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -67,35 +67,19 @@ func (pid ID) String() string {
 	return string(text)
 }
 
-type InstanceID []byte
-
-func NewInstanceID() InstanceID {
-	return xid.New().Bytes()
-}
-
-func (iid InstanceID) IsNil() bool {
-	return iid == nil
-}
-
-func (iid InstanceID) String() string {
-	return encoding.EncodeToString(iid)
-}
-
 type Meta struct {
 	ProfileID  ID          `json:"profile_id"`
 	Service    string      `json:"service"`
 	Type       ProfileType `json:"type"`
-	InstanceID InstanceID  `json:"instance_id"`
 	Labels     Labels      `json:"labels,omitempty"`
 	CreatedAt  time.Time   `json:"created_at,omitempty"`
 }
 
-func NewProfileMeta(service string, ptyp ProfileType, iid InstanceID, labels Labels) Meta {
+func NewProfileMeta(service string, ptyp ProfileType, labels Labels) Meta {
 	return Meta{
 		ProfileID:  NewID(),
 		Service:    service,
 		Type:       ptyp,
-		InstanceID: iid,
 		Labels:     labels,
 		CreatedAt:  time.Now().UTC(),
 	}

--- a/pkg/storage/badger/integration_test.go
+++ b/pkg/storage/badger/integration_test.go
@@ -27,11 +27,10 @@ func TestStorage_WriteFind(t *testing.T) {
 
 	service := "test-service-1"
 	meta := profile.Meta{
-		ProfileID:  profile.NewID(),
-		Service:    service,
-		Type:       profile.CPUProfile,
-		InstanceID: profile.NewInstanceID(),
-		Labels:     profile.Labels{{"key1", "val1"}},
+		ProfileID: profile.NewID(),
+		Service:   service,
+		Type:      profile.CPUProfile,
+		Labels:    profile.Labels{{"key1", "val1"}},
 	}
 
 	data := testWriteProfile(t, st, "../../../testdata/collector_cpu_1.prof", meta)
@@ -69,17 +68,16 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 	st, teardown := setupTestStorage(t)
 	defer teardown()
 
-	iid := profile.NewInstanceID()
-	service := fmt.Sprintf("test-service-%s", iid)
+	service1 := "test-service-1"
+	service2 := "test-service-2"
 
 	for n := 1; n <= 2; n++ {
 		fileName := fmt.Sprintf("../../../testdata/collector_cpu_%d.prof", n)
 		meta := profile.Meta{
-			ProfileID:  profile.NewID(),
-			Service:    service,
-			Type:       profile.CPUProfile,
-			InstanceID: iid,
-			Labels:     profile.Labels{{"key1", "val1"}},
+			ProfileID: profile.NewID(),
+			Service:   service1,
+			Type:      profile.CPUProfile,
+			Labels:    profile.Labels{{"key1", "val1"}},
 		}
 		testWriteProfile(t, st, fileName, meta)
 	}
@@ -90,11 +88,10 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		st,
 		"../../../testdata/collector_cpu_3.prof",
 		profile.Meta{
-			ProfileID:  profile.NewID(),
-			Service:    "another-service",
-			Type:       profile.CPUProfile,
-			InstanceID: profile.NewInstanceID(),
-			Labels:     profile.Labels{{"key1", "val1"}},
+			ProfileID: profile.NewID(),
+			Service:   service2,
+			Type:      profile.CPUProfile,
+			Labels:    profile.Labels{{"key1", "val1"}},
 		},
 	)
 
@@ -104,11 +101,10 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		st,
 		"../../../testdata/collector_heap_1.prof",
 		profile.Meta{
-			ProfileID:  profile.NewID(),
-			Service:    service,
-			Type:       profile.HeapProfile,
-			InstanceID: iid,
-			Labels:     profile.Labels{{"key1", "val1"}, {"key2", "val2"}},
+			ProfileID: profile.NewID(),
+			Service:   service1,
+			Type:      profile.HeapProfile,
+			Labels:    profile.Labels{{"key1", "val1"}, {"key2", "val2"}},
 		},
 	)
 
@@ -118,11 +114,10 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 		st,
 		"../../../testdata/collector_heap_2.prof",
 		profile.Meta{
-			ProfileID:  profile.NewID(),
-			Service:    service,
-			Type:       profile.HeapProfile,
-			InstanceID: iid,
-			Labels:     profile.Labels{{"key3", "val3"}},
+			ProfileID: profile.NewID(),
+			Service:   service1,
+			Type:      profile.HeapProfile,
+			Labels:    profile.Labels{{"key3", "val3"}},
 		},
 	)
 
@@ -131,7 +126,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("by service", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			CreatedAtMin: createdAtMin,
 		}
 		ids, err := st.FindProfileIDs(context.Background(), params)
@@ -141,7 +136,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("by service type", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			Type:         profile.CPUProfile,
 			CreatedAtMin: createdAtMin,
 		}
@@ -152,7 +147,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("by service labels", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			Labels:       profile.Labels{{"key1", "val1"}},
 			CreatedAtMin: createdAtMin,
 		}
@@ -163,7 +158,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("by service labels type", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			Type:         profile.HeapProfile,
 			Labels:       profile.Labels{{"key2", "val2"}},
 			CreatedAtMin: createdAtMin,
@@ -175,7 +170,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("with limit", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			CreatedAtMin: createdAtMin,
 			Limit:        2,
 		}
@@ -186,7 +181,7 @@ func TestStorage_FindProfileIDs_Indexes(t *testing.T) {
 
 	t.Run("nothing found", func(t *testing.T) {
 		params := &storage.FindProfilesParams{
-			Service:      service,
+			Service:      service1,
 			Type:         profile.HeapProfile,
 			Labels:       profile.Labels{{"key3", "val1"}},
 			CreatedAtMin: createdAtMin,
@@ -200,8 +195,7 @@ func TestStorage_ListProfiles_MultipleResults(t *testing.T) {
 	st, teardown := setupTestStorage(t)
 	defer teardown()
 
-	iid := profile.NewInstanceID()
-	service := fmt.Sprintf("test-service-%s", iid)
+	service1 := "test-service-1"
 
 	var (
 		pids []profile.ID
@@ -213,11 +207,10 @@ func TestStorage_ListProfiles_MultipleResults(t *testing.T) {
 		pids = append(pids, pid)
 		fileName := fmt.Sprintf("../../../testdata/collector_cpu_%d.prof", n)
 		meta := profile.Meta{
-			ProfileID:  pid,
-			Service:    service,
-			Type:       profile.CPUProfile,
-			InstanceID: iid,
-			Labels:     profile.Labels{{"key1", "val1"}},
+			ProfileID: pid,
+			Service:   service1,
+			Type:      profile.CPUProfile,
+			Labels:    profile.Labels{{"key1", "val1"}},
 		}
 		data := testWriteProfile(t, st, fileName, meta)
 

--- a/scripts/pprof_import.sh
+++ b/scripts/pprof_import.sh
@@ -10,7 +10,6 @@ usuage() {
 
 service=
 labels=
-instance_id="imported-profile"
 prof_type=
 
 while true
@@ -65,7 +64,7 @@ api_profile_url="$PROFEFE_COLLECTOR/api/0/profiles"
 create_profile() {
     local file_path="$1"
     echo -n "uploading ${file_path}..."
-    curl -s -XPOST "$api_profile_url?service=$service&instance_id=$instance_id&type=$prof_type&labels=$labels" --data-binary "@$file_path" >/dev/null
+    curl -s -XPOST "${api_profile_url}?service=${service}&type=${prof_type}&labels=${labels}" --data-binary "@${file_path}" >/dev/null
     echo "OK"
 }
 


### PR DESCRIPTION
`instance_id` was an artefact from the earlier prototypes of profefe. It helped to simplify the first version of storage, which was based on PostgreSQL (refer to https://github.com/profefe/profefe/pull/28 why it didn't work).

As it's now `instance_id` is a rudiment that is never stored and doesn't do anything.