### PR TITLE
Return list of services

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the profiling samples base on metadata associated with the application.
 
 ---
 
-**The project is still in its early stage. Opinions and contributions are welcome.**
+**The project is still in its early state. Feedback and contribution are very welcome.**
 
 ---
 
@@ -169,9 +169,38 @@ GET /api/0/profiles/<id>
 
 - `id` - id of stored pprof file; returned with the request for meta information query
 
-## Feedback
+### Get services for which profiling data is stored
 
-The feedback and contribution are very welcome.
+```
+GET /api/0/services
+
+< 200 OK
+<
+{
+  "code": 200,
+  "body": [
+    <service1>,
+    ···
+  ]
+}
+```
+
+### Get profefe server version
+
+```
+GET /api/0/version
+
+< 200 OK
+<
+{
+  "code": 200,
+  "body": {
+    "version": <version>,
+    "commit": <git revision>,
+    "build_time": <build timestamp>"
+  }
+}
+```
 
 ## Further reading
 

--- a/pkg/profefe/querier.go
+++ b/pkg/profefe/querier.go
@@ -18,8 +18,8 @@ type Querier struct {
 
 func NewQuerier(logger *log.Logger, sr storage.Reader) *Querier {
 	return &Querier{
-		sr:     sr,
 		logger: logger,
+		sr:     sr,
 	}
 }
 
@@ -77,4 +77,8 @@ func (q *Querier) FindMergeProfileTo(ctx context.Context, dst io.Writer, params 
 		return xerrors.Errorf("could not merge %d profiles: %w", len(pps), err)
 	}
 	return pp.Write(dst)
+}
+
+func (q *Querier) GetServices(ctx context.Context) ([]string, error) {
+	return q.sr.ListServices(ctx)
 }

--- a/pkg/profefe/routes.go
+++ b/pkg/profefe/routes.go
@@ -10,6 +10,7 @@ import (
 const (
 	apiProfilesPath      = "/api/0/profiles"
 	apiProfilesMergePath = "/api/0/profiles/merge"
+	apiServicesPath      = "/api/0/services"
 	apiVersionPath       = "/api/0/version"
 )
 
@@ -24,6 +25,8 @@ func SetupRoutes(
 
 	mux.HandleFunc(apiVersionPath, VersionHandler)
 
-	// XXX(narqo): everything below /api/0/ is served by profiles handler
+	mux.Handle(apiServicesPath, NewServicesHandler(logger, querier))
+
+	// XXX(narqo): everything else under /api/0/ is served by profiles handler
 	mux.Handle("/api/0/", NewProfilesHandler(logger, collector, querier))
 }

--- a/pkg/profefe/services_handler.go
+++ b/pkg/profefe/services_handler.go
@@ -1,0 +1,40 @@
+package profefe
+
+import (
+	"net/http"
+
+	"github.com/profefe/profefe/pkg/log"
+	"github.com/profefe/profefe/pkg/storage"
+)
+
+type ServicesHandler struct {
+	logger  *log.Logger
+	querier *Querier
+}
+
+func NewServicesHandler(logger *log.Logger, querier *Querier) *ServicesHandler {
+	return &ServicesHandler{
+		logger:  logger,
+		querier: querier,
+	}
+}
+
+func (h *ServicesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.URL.Path != apiServicesPath {
+		HandleErrorHTTP(h.logger, ErrNotFound, w, r)
+		return
+	}
+
+	services, err := h.querier.GetServices(r.Context())
+	if err != nil {
+		if err == storage.ErrNotFound {
+			err = ErrNotFound
+		}
+		HandleErrorHTTP(h.logger, err, w, r)
+		return
+	}
+
+	ReplyJSON(w, services)
+}

--- a/pkg/profefe/services_handler_test.go
+++ b/pkg/profefe/services_handler_test.go
@@ -1,0 +1,83 @@
+package profefe
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/profefe/profefe/pkg/log"
+	"github.com/profefe/profefe/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/xerrors"
+)
+
+func TestServicesHandler_success(t *testing.T) {
+	services := []string{"service1", "service2"}
+	sr := &storage.MockReader{
+		ListServicesMock: func(ctx context.Context) ([]string, error) {
+			return services, nil
+		},
+	}
+
+	testLogger := log.New(zaptest.NewLogger(t))
+	querier := NewQuerier(testLogger, sr)
+	h := NewServicesHandler(testLogger, querier)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/0/services", nil)
+	require.NoError(t, err)
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp jsonResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Empty(t, resp.Error)
+	assert.ElementsMatch(t, services, resp.Body.([]interface{}))
+}
+
+func TestServicesHandler_nothingFound(t *testing.T) {
+	sr := &storage.MockReader{
+		ListServicesMock: func(ctx context.Context) ([]string, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	testLogger := log.New(zaptest.NewLogger(t))
+	querier := NewQuerier(testLogger, sr)
+	h := NewServicesHandler(testLogger, querier)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/0/services", nil)
+	require.NoError(t, err)
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestServicesHandler_storageFailure(t *testing.T) {
+	sr := &storage.MockReader{
+		ListServicesMock: func(ctx context.Context) ([]string, error) {
+			return nil, xerrors.New("unexpected storage error")
+		},
+	}
+
+	testLogger := log.New(zaptest.NewLogger(t))
+	querier := NewQuerier(testLogger, sr)
+	h := NewServicesHandler(testLogger, querier)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/0/services", nil)
+	require.NoError(t, err)
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/pkg/storage/badger/badger.go
+++ b/pkg/storage/badger/badger.go
@@ -39,6 +39,8 @@ type Storage struct {
 	logger *log.Logger
 	db     *badger.DB
 	ttl    time.Duration
+	// holds the cache of stored services
+	cache *cache
 }
 
 var _ storage.Reader = (*Storage)(nil)
@@ -49,6 +51,7 @@ func New(logger *log.Logger, db *badger.DB, ttl time.Duration) *Storage {
 		logger: logger,
 		db:     db,
 		ttl:    ttl,
+		cache:  newCache(db),
 	}
 }
 
@@ -66,9 +69,13 @@ func (st *Storage) WriteProfile(ctx context.Context, meta profile.Meta, r io.Rea
 }
 
 func (st *Storage) writeProfileData(ctx context.Context, meta profile.Meta, data []byte) error {
-	entries := make([]*badger.Entry, 0, 1+1+2+len(meta.Labels)) // 1 for profile entry, 1 for meta entry, 2 for general indexes
-
+	var expiresAt uint64
+	if st.ttl > 0 {
+		expiresAt = uint64(time.Now().Add(st.ttl).Unix())
+	}
 	createdAt := meta.CreatedAt.UnixNano()
+
+	entries := make([]*badger.Entry, 0, 1+1+2+len(meta.Labels)) // 1 for profile entry, 1 for meta entry, 2 for general indexes
 
 	entries = append(entries, st.newBadgerEntry(createProfilePK(meta.ProfileID, createdAt), data))
 
@@ -103,7 +110,7 @@ func (st *Storage) writeProfileData(ctx context.Context, meta profile.Meta, data
 		}
 	}
 
-	return st.db.Update(func(txn *badger.Txn) error {
+	err = st.db.Update(func(txn *badger.Txn) error {
 		for i := range entries {
 			st.logger.Debugw("writeProfile: set entry", "pid", meta.ProfileID, log.ByteString("key", entries[i].Key), "expires_at", entries[i].ExpiresAt)
 			if err := txn.SetEntry(entries[i]); err != nil {
@@ -112,6 +119,13 @@ func (st *Storage) writeProfileData(ctx context.Context, meta profile.Meta, data
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	st.cache.PutService(meta.Service, expiresAt)
+
+	return nil
 }
 
 func (st *Storage) newBadgerEntry(key, val []byte) *badger.Entry {
@@ -164,39 +178,9 @@ func appendLabelKV(b []byte, key, val string) []byte {
 }
 
 func (st *Storage) ListServices(ctx context.Context) ([]string, error) {
-	uniqueServices := make(map[string]uint64)
-	err := st.db.View(func(txn *badger.Txn) error {
-		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = false // keys-only iteration
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		prefix := []byte{serviceIndexID}
-
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			key := it.Item().Key()
-			service := key[1 : len(key)-sizeOfProfileID-8] // 8 is for ts-nanos
-			if v, ok := uniqueServices[string(service)]; ok {
-				if v < it.Item().ExpiresAt() {
-					delete(uniqueServices, string(service))
-				}
-			} else {
-				uniqueServices[string(service)] = it.Item().ExpiresAt()
-			}
-		}
-
-		if len(uniqueServices) == 0 {
-			return storage.ErrNotFound
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	services := make([]string, 0, len(uniqueServices))
-	for service := range uniqueServices {
-		services = append(services, service)
+	services := st.cache.Services()
+	if len(services) == 0 {
+		return nil, storage.ErrNotFound
 	}
 	return services, nil
 }

--- a/pkg/storage/badger/cache.go
+++ b/pkg/storage/badger/cache.go
@@ -1,0 +1,78 @@
+package badger
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/dgraph-io/badger"
+)
+
+type cache struct {
+	mu       sync.RWMutex
+	services map[string]uint64
+}
+
+func newCache(db *badger.DB) *cache {
+	c := &cache{
+		services: make(map[string]uint64),
+	}
+
+	c.prefillServices(db)
+
+	return c
+}
+
+func (cache *cache) prefillServices(db *badger.DB) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	return db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false // keys-only iteration
+
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{serviceIndexID}
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			key := it.Item().Key()
+			keyTTL := it.Item().ExpiresAt()
+			service := key[1 : len(key)-sizeOfProfileID-8] // 8 is for ts-nanos
+			if v, ok := cache.services[string(service)]; ok {
+				if v > keyTTL {
+					continue
+				}
+			}
+			cache.services[string(service)] = keyTTL
+		}
+		return nil
+	})
+}
+
+func (cache *cache) PutService(service string, expiresAt uint64) {
+	cache.mu.Lock()
+	cache.services[service] = expiresAt
+	cache.mu.Unlock()
+}
+
+func (cache *cache) Services() []string {
+	now := time.Now().Unix()
+	services := make([]string, 0, len(cache.services))
+
+	cache.mu.RLock()
+	for s, v := range cache.services {
+		if v > uint64(now) || v == 0 {
+			services = append(services, s)
+		} else {
+			// the key has expired
+			delete(cache.services, s)
+		}
+	}
+	cache.mu.RUnlock()
+
+	sort.Strings(services)
+
+	return services
+}

--- a/pkg/storage/mock.go
+++ b/pkg/storage/mock.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/profefe/profefe/pkg/profile"
+)
+
+type WriteProfileMock func(ctx context.Context, meta profile.Meta, r io.Reader) error
+
+type MockWriter struct {
+	WriteProfileMock
+}
+
+var _ Writer = (*MockWriter)(nil)
+
+func (sw *MockWriter) WriteProfile(ctx context.Context, meta profile.Meta, r io.Reader) error {
+	return sw.WriteProfileMock(ctx, meta, r)
+}
+
+type ListServicesMock func(ctx context.Context) ([]string, error)
+
+type FindProfilesMock func(ctx context.Context, params *FindProfilesParams) ([]profile.Meta, error)
+
+type FindProfileIDsMock func(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error)
+
+type ListProfilesMock func(ctx context.Context, pid []profile.ID) (ProfileList, error)
+
+type MockReader struct {
+	ListServicesMock
+	ListProfilesMock
+	FindProfilesMock
+	FindProfileIDsMock
+}
+
+var _ Reader = (*MockReader)(nil)
+
+func (sr *MockReader) ListServices(ctx context.Context) ([]string, error) {
+	return sr.ListServicesMock(ctx)
+}
+
+func (sr *MockReader) FindProfiles(ctx context.Context, params *FindProfilesParams) ([]profile.Meta, error) {
+	return sr.FindProfilesMock(ctx, params)
+}
+
+func (sr *MockReader) FindProfileIDs(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error) {
+	return sr.FindProfileIDsMock(ctx, params)
+}
+
+func (sr *MockReader) ListProfiles(ctx context.Context, pid []profile.ID) (ProfileList, error) {
+	return sr.ListProfilesMock(ctx, pid)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,6 +20,7 @@ type Writer interface {
 }
 
 type Reader interface {
+	ListServices(ctx context.Context) ([]string, error)
 	FindProfiles(ctx context.Context, params *FindProfilesParams) ([]profile.Meta, error)
 	FindProfileIDs(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error)
 	ListProfiles(ctx context.Context, pid []profile.ID) (ProfileList, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,10 +20,10 @@ type Writer interface {
 }
 
 type Reader interface {
-	ListServices(ctx context.Context) ([]string, error)
 	FindProfiles(ctx context.Context, params *FindProfilesParams) ([]profile.Meta, error)
 	FindProfileIDs(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error)
 	ListProfiles(ctx context.Context, pid []profile.ID) (ProfileList, error)
+	ListServices(ctx context.Context) ([]string, error)
 }
 
 type FindProfilesParams struct {


### PR DESCRIPTION
closes #49 

TODO
- [x] (storage/badger) instead of iterating over all keys in the index on every request, implement an in-memory cache that will be populated on storage initialisation, updated on write, and from where `ListServices` will return the list (_a dumb `map[service]ttl` will work_);
- [x] (profefe) add `ListServices` to querier;
- [x] (profefe) add new API route `/api/0/services`;
- [x] (docs) update API section in readme.