### PR TITLE
ci: build docker image with buildkit on push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: bionic
+
 language: go
 go:
   - 1.x
@@ -7,3 +8,29 @@ jobs:
   include:
     - stage: test
       script: make test
+
+    - stage: deploy docker
+      if: type != pull_request
+      services: docker
+      env:
+        - GITSHA=$TRAVIS_COMMIT
+        - PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+      install:
+        - docker container run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        - docker container run -d --rm --name buildkitd --privileged moby/buildkit:latest
+        - sudo docker container cp buildkitd:/usr/bin/buildctl /usr/local/bin/
+        - export BUILDKIT_HOST="docker-container://buildkitd"
+      script:
+        - export VERSION=git-$(echo $GITSHA | cut -c 1-7)
+      deploy:
+        - provider: script
+          script: bash ./scripts/ci_build_image.sh --push $TRAVIS_REPO_SLUG $VERSION latest
+          on:
+            repo: profefe/profefe
+            branch: master
+      before_deploy:
+        - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+      after_failure:
+        - buildctl debug workers ls
+        - docker container logs buildkitd
+

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,8 @@ LDFLAGS += -X $(PKG)/version.Version=$(VERSION)
 LDFLAGS += -X $(PKG)/version.Commit=$(GITSHA)
 LDFLAGS += -X $(PKG)/version.BuildTime=$(BUILDTIME)
 
-IMAGE_VERSION := $(VERSION)
 DOCKER_IMAGE := profefe/profefe
-
-DOCKER_BUILD_ARGS += --build-arg VERSION=$(VERSION)
-DOCKER_BUILD_ARGS += --build-arg GITSHA=$(GITSHA)
+DOCKER_IMAGE_TAG := $(VERSION)
 
 BUILDDIR := BUILD
 
@@ -44,10 +41,5 @@ test:
 
 .PHONY: docker-image
 docker-image:
-	$(DOCKER) build $(DOCKER_BUILD_ARGS) -t $(DOCKER_IMAGE):$(IMAGE_VERSION) -f ./contrib/docker/Dockerfile .
-
-.PHONY: docker-push-image
-docker-push-image: docker-image
-	$(DOCKER) tag $(DOCKER_IMAGE):$(IMAGE_VERSION) $(DOCKER_IMAGE):latest
-	$(DOCKER) push $(DOCKER_IMAGE):$(IMAGE_VERSION)
-	$(DOCKER) push $(DOCKER_IMAGE):latest
+	GITSHA=$(GITSHA) VERSION=$(VERSION) \
+		./scripts/ci_build_image.sh $(DOCKER_IMAGE) $(DOCKER_IMAGE_TAG)

--- a/scripts/ci_build_image.sh
+++ b/scripts/ci_build_image.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -eu
+
+: ${CI=}
+: ${DOCKER=docker}
+: ${BUILDCTL=buildctl}
+
+: ${PLATFORMS=linux/amd64}
+
+PUSH_IMAGE=
+if [ "$1" == "--push" ]; then
+    PUSH_IMAGE=push
+    shift
+fi
+
+IMAGE=$1
+shift
+IMAGE_TAGS="$*"
+
+DOCKERFILE=contrib/docker/Dockerfile
+
+docker_build() {
+    local tag_args=
+    for tag in $IMAGE_TAGS; do
+        tag_args="$tag_args --tag $IMAGE:$tag"
+    done
+
+    set -x
+
+    $DOCKER build \
+        --build-arg VERSION=$VERSION \
+        --build-arg GITSHA=$GITSHA \
+        $tag_args -f $DOCKERFILE .
+}
+
+buildctl_build() {
+    local image_name=
+    for tag in $IMAGE_TAGS; do
+        [ -n "$image_name" ] && image_name="${image_name},"
+        image_name="${image_name}${IMAGE}:${tag}"
+    done
+
+    local push_arg=
+    if [ "$PUSH_IMAGE" == "push" ]; then
+        push_arg=",push=true"
+    fi
+
+    set -x
+
+    $BUILDCTL build \
+        --progress=plain \
+        --frontend=dockerfile.v0 \
+        --local context=. --local dockerfile=. \
+        --opt filename=$DOCKERFILE \
+        --opt platform=$PLATFORMS \
+        --opt build-arg:VERSION=\"$VERSION\" \
+        --opt build-arg:GITSHA=\"$GITSHA\" \
+        --output type=image,\"name=$image_name\"$push_arg
+}
+
+if [ "$CI" == "true" ]; then
+    buildctl_build
+else
+    docker_build
+fi


### PR DESCRIPTION
On push to `master`, Travis CI runs the deploy build stage that builds docker image for specified platforms (using [buildkit][1]) and pushes the image to docker hub.

[1]: https://github.com/moby/buildkit