### PR TITLE
Allow Querier to bail out from FindMergeProfileTo if context was cancelled

### DIFF
--- a/pkg/profefe/querier.go
+++ b/pkg/profefe/querier.go
@@ -65,6 +65,13 @@ func (q *Querier) FindMergeProfileTo(ctx context.Context, dst io.Writer, params 
 
 	pps := make([]*pprofProfile.Profile, 0, len(pids))
 	for list.Next() {
+		// exit fast if context canceled
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		p, err := list.Profile()
 		if err != nil {
 			return err

--- a/pkg/profefe/querier_test.go
+++ b/pkg/profefe/querier_test.go
@@ -1,0 +1,50 @@
+package profefe
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	pprofProfile "github.com/profefe/profefe/internal/pprof/profile"
+	"github.com/profefe/profefe/pkg/log"
+	"github.com/profefe/profefe/pkg/profile"
+	"github.com/profefe/profefe/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestQuerier_FindMergeProfileTo_contextCancelled(t *testing.T) {
+	sr := &storage.MockReader{
+		FindProfileIDsMock: func(ctx context.Context, _ *storage.FindProfilesParams) ([]profile.ID, error) {
+			return []profile.ID{profile.NewID()}, nil
+		},
+		ListProfilesMock: func(ctx context.Context, _ []profile.ID) (storage.ProfileList, error) {
+			return &unboundProfileList{}, nil
+		},
+	}
+
+	testLogger := log.New(zaptest.NewLogger(t))
+	querier := NewQuerier(testLogger, sr)
+
+	// because we cancel the context, the find call below will exit w/o reading the whole (unbound) profile list
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	params := &storage.FindProfilesParams{
+		Service:      "test-server",
+		CreatedAtMin: time.Now(),
+	}
+	err := querier.FindMergeProfileTo(ctx, ioutil.Discard, params)
+	assert.Equal(t, context.Canceled, err)
+}
+
+// unbound profile list whose Next method always returns true
+type unboundProfileList struct{}
+
+func (pl *unboundProfileList) Next() bool {
+	return true
+}
+
+func (pl *unboundProfileList) Profile() (p *pprofProfile.Profile, err error) { return }
+func (pl *unboundProfileList) Close() (err error)                            { return }

--- a/pkg/profefe/querier_test.go
+++ b/pkg/profefe/querier_test.go
@@ -15,12 +15,13 @@ import (
 )
 
 func TestQuerier_FindMergeProfileTo_contextCancelled(t *testing.T) {
+	list := &unboundProfileList{}
 	sr := &storage.MockReader{
 		FindProfileIDsMock: func(ctx context.Context, _ *storage.FindProfilesParams) ([]profile.ID, error) {
 			return []profile.ID{profile.NewID()}, nil
 		},
 		ListProfilesMock: func(ctx context.Context, _ []profile.ID) (storage.ProfileList, error) {
-			return &unboundProfileList{}, nil
+			return list, nil
 		},
 	}
 
@@ -37,14 +38,22 @@ func TestQuerier_FindMergeProfileTo_contextCancelled(t *testing.T) {
 	}
 	err := querier.FindMergeProfileTo(ctx, ioutil.Discard, params)
 	assert.Equal(t, context.Canceled, err)
+
+	assert.True(t, list.closed, "profile list must be closed")
 }
 
 // unbound profile list whose Next method always returns true
-type unboundProfileList struct{}
+type unboundProfileList struct {
+	closed bool
+}
 
 func (pl *unboundProfileList) Next() bool {
 	return true
 }
 
+func (pl *unboundProfileList) Close() error {
+	pl.closed = true
+	return nil
+}
+
 func (pl *unboundProfileList) Profile() (p *pprofProfile.Profile, err error) { return }
-func (pl *unboundProfileList) Close() (err error)                            { return }


### PR DESCRIPTION
If the request to `api/0/profiles/merge` is closed while collector is still reading profiles from the storage, `Querier` can bailout, returning `context.Canceled` error.

If the same request is closed after all profiles were read, `Querier` will fail with `"write: broken pipe"` when it will try to write the result to the client. Note, this is still not perfect, e.g. if merging takes more time than reading profiles from storage.