### PR TITLE
Update get profile API to allow merging profiles by IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ GET /api/0/profiles/<id>
 
 - `id` - id of stored profile, returned with the request for meta information above
 
+#### Merge a set of individual profiles into a single profile
+
+```
+GET /api/0/profiles/<id1>+<id2>+...
+
+< 200 OK
+< pprof.pb.gz
+```
+
+- `id1`, `id2` - ids of stored profiles
+
+*Note, merging is possible only for profiles of the same type.*
+
 ### Get services for which profiling data is stored
 
 ```

--- a/pkg/profefe/querier_test.go
+++ b/pkg/profefe/querier_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"github.com/profefe/profefe/pkg/log"
 	"github.com/profefe/profefe/pkg/profile"
@@ -14,13 +13,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func TestQuerier_FindMergeProfileTo_contextCancelled(t *testing.T) {
+func TestQuerier_GetProfilesTo_contextCancelled(t *testing.T) {
 	list := &unboundProfileList{}
 	sr := &storage.StubReader{
-		FindProfileIDsFunc: func(ctx context.Context, _ *storage.FindProfilesParams) ([]profile.ID, error) {
-			return []profile.ID{profile.TestID}, nil
-		},
-		ListProfilesfunc: func(ctx context.Context, _ []profile.ID) (storage.ProfileList, error) {
+		ListProfilesFunc: func(ctx context.Context, _ []profile.ID) (storage.ProfileList, error) {
 			return list, nil
 		},
 	}
@@ -28,15 +24,11 @@ func TestQuerier_FindMergeProfileTo_contextCancelled(t *testing.T) {
 	testLogger := log.New(zaptest.NewLogger(t))
 	querier := NewQuerier(testLogger, sr)
 
-	// because we cancel the context, the find call below will exit w/o reading the whole (unbound) profile list
+	// because we cancel the context, the get call below will exit w/o reading the whole (unbound) profile list
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	params := &storage.FindProfilesParams{
-		Service:      "test-server",
-		CreatedAtMin: time.Now(),
-	}
-	err := querier.FindMergeProfileTo(ctx, ioutil.Discard, params)
+	err := querier.GetProfilesTo(ctx, ioutil.Discard, []profile.ID{"p1", "p2"})
 	assert.Equal(t, context.Canceled, err)
 
 	assert.True(t, list.closed, "profile list must be closed")

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,12 +1,47 @@
 package profile
 
 import (
+	"fmt"
+	"strings"
 	"time"
 )
 
 const TestID = ID("bpc00mript33iv4net00")
 
 type ID string
+
+func JoinIDs(ids ...ID) (string, error) {
+	if len(ids) == 0 {
+		return "", nil
+	}
+	var buf strings.Builder
+	for n, id := range ids {
+		if n > 0 {
+			buf.WriteByte('+')
+		}
+		sid := string(id)
+		if strings.ContainsRune(sid, '+') {
+			return "", fmt.Errorf("could not join %v: found recerved char in %q", ids, id)
+		}
+		buf.WriteString(sid)
+	}
+	return buf.String(), nil
+}
+
+func SplitIDs(s string) ([]ID, error) {
+	if s == "" {
+		return nil, nil
+	}
+	ss := strings.Split(s, "+")
+	ids := make([]ID, len(ss))
+	for i, sid := range ss {
+		if sid == "" {
+			return nil, fmt.Errorf("could not split %q: found empty id at %d", s, i)
+		}
+		ids[i] = ID(sid)
+	}
+	return ids, nil
+}
 
 type Meta struct {
 	ProfileID ID          `json:"profile_id"`

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,97 @@
+package profile
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinIDs(t *testing.T) {
+	cases := []struct {
+		ids     []ID
+		want    string
+		wantErr bool
+	}{
+		{
+			nil,
+			"",
+			false,
+		},
+		{
+			[]ID{},
+			"",
+			false,
+		},
+		{
+			[]ID{TestID},
+			string(TestID),
+			false,
+		},
+		{
+			[]ID{"bpc00mript33iv4net01", "bpc00mript33iv4net02", "bpc00mript33iv4net03"},
+			"bpc00mript33iv4net01+bpc00mript33iv4net02+bpc00mript33iv4net03",
+			false,
+		},
+		{
+			[]ID{"P0.svc1/1/bpc00mript33iv4net01,k1=v1,k2=v2", "P0.svc1/1/bpc00mript33iv4net02,k1=v1,k2=v2"},
+			"P0.svc1/1/bpc00mript33iv4net01,k1=v1,k2=v2+P0.svc1/1/bpc00mript33iv4net02,k1=v1,k2=v2",
+			false,
+		},
+		{
+			[]ID{"P0.svc1/1/bpc00mript33iv4net01+k1=v1,k2=v2"},
+			"",
+			true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(fmt.Sprintf("case=%d", n), func(t *testing.T) {
+			s, err := JoinIDs(tc.ids...)
+			require.True(t, (err != nil) == tc.wantErr, "want err %v, got %v", tc.wantErr, err)
+			require.Equal(t, tc.want, s)
+		})
+	}
+}
+
+func TestSplitIDs(t *testing.T) {
+	cases := []struct {
+		ids     string
+		want    []ID
+		wantErr bool
+	}{
+		{
+			"",
+			nil,
+			false,
+		},
+		{
+			string(TestID),
+			[]ID{TestID},
+			false,
+		},
+		{
+			"bpc00mript33iv4net01+bpc00mript33iv4net02+bpc00mript33iv4net03",
+			[]ID{"bpc00mript33iv4net01", "bpc00mript33iv4net02", "bpc00mript33iv4net03"},
+			false,
+		},
+		{
+			"P0.svc1/1/bpc00mript33iv4net01,k1=v1,k2=v2+P0.svc1/1/bpc00mript33iv4net02,k1=v1,k2=v2",
+			[]ID{"P0.svc1/1/bpc00mript33iv4net01,k1=v1,k2=v2", "P0.svc1/1/bpc00mript33iv4net02,k1=v1,k2=v2"},
+			false,
+		},
+		{
+			"bpc00mript33iv4net01++bpc00mript33iv4net02",
+			nil,
+			true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(fmt.Sprintf("case=%d", n), func(t *testing.T) {
+			ids, err := SplitIDs(tc.ids)
+			require.True(t, (err != nil) == tc.wantErr, "want err %v, got %v", tc.wantErr, err)
+			require.ElementsMatch(t, tc.want, ids)
+		})
+	}
+}

--- a/pkg/storage/stub.go
+++ b/pkg/storage/stub.go
@@ -25,11 +25,11 @@ type FindProfilesFunc func(ctx context.Context, params *FindProfilesParams) ([]p
 
 type FindProfileIDsFunc func(ctx context.Context, params *FindProfilesParams) ([]profile.ID, error)
 
-type ListProfilesfunc func(ctx context.Context, pid []profile.ID) (ProfileList, error)
+type ListProfilesFunc func(ctx context.Context, pid []profile.ID) (ProfileList, error)
 
 type StubReader struct {
 	ListServicesFunc
-	ListProfilesfunc
+	ListProfilesFunc
 	FindProfilesFunc
 	FindProfileIDsFunc
 }
@@ -49,5 +49,5 @@ func (sr *StubReader) FindProfileIDs(ctx context.Context, params *FindProfilesPa
 }
 
 func (sr *StubReader) ListProfiles(ctx context.Context, pid []profile.ID) (ProfileList, error) {
-	return sr.ListProfilesfunc(ctx, pid)
+	return sr.ListProfilesFunc(ctx, pid)
 }


### PR DESCRIPTION
The PR updates `/api/0/profiles` API to allow passing multiple profile IDs (using `+` as ids' separator):

```
GET /api/0/profiles/id1+id2+id3
```

The API returns a single profile, that contains all profiles merged into one. 

This change effectively makes `/api/0/profiles/merge?service=svc1` an alias for

```
> GET /api/profiles?service=svc1 | jq '.body | .[] | .id'
id1
id2
id3

> GET /api/profiles/id1+id2+id3
```