### PR TITLE
fix: get profile from s3

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -333,7 +333,7 @@ func (st *Storage) findProfiles(ctx context.Context, params *storage.FindProfile
 func (st *Storage) getObject(ctx context.Context, w io.WriterAt, key string) error {
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(st.bucket),
-		Key:    aws.String(key),
+		Key:    aws.String("/profiles/" + key),
 	}
 	n, err := st.downloader.DownloadWithContext(ctx, w, input)
 	if err != nil {


### PR DESCRIPTION
Hello

I wrote you an email with my problem but I will report some of the
information here:

Version: `profefe/profefe:git-668a19d`

This version changed the shape of the profile ID returned by the API:

Now it is `P0.service/4/bq0rups0s6cfii5dn030,from=label,label2=label2,` before it was `bq0rups0s6cfii5dn030`

I was not able to get a single profile back because the reader is not
finding it to S3. This PR contains the fix. It works for me but I am not
sure if this is how it should work. I would still like to get the old ID
back.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>