### PR TITLE
fix(s3): s3 returns profiles too old via the get profiles API

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -293,6 +293,10 @@ func (st *Storage) findProfiles(ctx context.Context, params *storage.FindProfile
 				continue
 			}
 
+			if meta.CreatedAt.Before(params.CreatedAtMin) {
+				continue
+			}
+
 			if meta.CreatedAt.After(createdAtMax) {
 				return false
 			}


### PR DESCRIPTION
Apparently S3 is not filtering profiles that are too old. This PR fixes
this issue.

Fixed #82

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>