### PR TITLE
Allow collector to read profiling data via agent

### DIFF
--- a/pkg/agentutil/confg.go
+++ b/pkg/agentutil/confg.go
@@ -1,0 +1,132 @@
+package agentutil
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/profefe/profefe/agent"
+	"github.com/profefe/profefe/pkg/log"
+	"github.com/profefe/profefe/pkg/profile"
+	"github.com/profefe/profefe/version"
+)
+
+const (
+	labelVersion = "version"
+)
+
+type Config struct {
+	CollectorAddr string
+	Service       string
+	Labels        profile.Labels `json:",omitempty"`
+
+	TickInterval time.Duration `json:",omitempty"`
+
+	CPUProfile            time.Duration `json:",omitempty"`
+	HeapProfile           bool          `json:",omitempty"`
+	BlockProfile          bool          `json:",omitempty"`
+	MutexProfile          bool          `json:",omitempty"`
+	GoroutineProfile      bool          `json:",omitempty"`
+	ThreadcreationProfile bool          `json:",omitempty"`
+	//TraceProfile          bool          `json:",omitempty"`
+}
+
+func (conf *Config) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&conf.CollectorAddr, "profefe.agent.collector-addr", "", "profefe collector public address to send profiling data")
+	f.StringVar(&conf.Service, "profefe.agent.service-name", "profefe", "application service name")
+
+	labels := (*labelsValue)(&conf.Labels)
+	f.Var(labels, "profefe.agent.labels", "application labels")
+
+	f.DurationVar(&conf.TickInterval, "profefe.agent.read-interval", 0, "how often agent reads profiling data")
+
+	f.DurationVar(&conf.CPUProfile, "profefe.agent.enable-cpu-profile", 10*time.Second, "enables CPU profiling (sets profile collection duration)")
+	f.BoolVar(&conf.HeapProfile, "profefe.agent.enable-heap-profile", false, "enables heap profiling")
+	f.BoolVar(&conf.BlockProfile, "profefe.agent.enable-block-profile", false, "enables block (contention) profiling")
+	f.BoolVar(&conf.MutexProfile, "profefe.agent.enable-mutex-profile", false, "enables mutex profiling")
+	f.BoolVar(&conf.GoroutineProfile, "profefe.agent.enable-goroutine-profile", false, "enables goroutine profiling")
+	f.BoolVar(&conf.ThreadcreationProfile, "profefe.agent.enable-thread-creation-profile", false, "enables thread creation profiling")
+	//f.BoolVar(&conf.TraceProfile, "profefe.agent.enable-trace-profile", false, "enables trace profiling")
+}
+
+func (conf *Config) Start(ctx context.Context, logger *log.Logger) error {
+	if conf.CollectorAddr == "" {
+		logger.Infow("profefe-agent disabled: no collector address", "config", conf)
+		return nil
+	}
+
+	opts := conf.options()
+
+	opts = append(opts, agent.WithLogger(func(s string, v ...interface{}) {
+		logger.Infof(s, v...)
+	}))
+
+	pffAgent, err := agent.Start(conf.CollectorAddr, conf.Service, opts...)
+	if err != nil {
+		return err
+	}
+
+	logger.Infow("profefe-agent is running", "config", conf)
+
+	go func() {
+		<-ctx.Done()
+		pffAgent.Stop()
+	}()
+
+	return nil
+}
+
+func (conf *Config) options() (opts []agent.Option) {
+	var labels []string
+	for _, label := range conf.Labels {
+		labels = append(labels, label.Key, label.Value)
+	}
+
+	labels = append(labels, labelVersion, version.Details().Version)
+
+	opts = append(opts, agent.WithLabels(labels...))
+
+	if conf.TickInterval != 0 {
+		opts = append(opts, agent.WithTickInterval(conf.TickInterval))
+	}
+
+	if conf.CPUProfile != 0 {
+		opts = append(opts, agent.WithCPUProfile(conf.CPUProfile))
+	}
+	if conf.HeapProfile {
+		opts = append(opts, agent.WithHeapProfile())
+	}
+	if conf.BlockProfile {
+		opts = append(opts, agent.WithBlockProfile())
+	}
+	if conf.MutexProfile {
+		opts = append(opts, agent.WithMutexProfile())
+	}
+	if conf.GoroutineProfile {
+		opts = append(opts, agent.WithGoroutineProfile())
+	}
+	if conf.ThreadcreationProfile {
+		opts = append(opts, agent.WithThreadcreateProfile())
+	}
+
+	return opts
+}
+
+type labelsValue profile.Labels
+
+func (v *labelsValue) Get() interface{} {
+	return (*profile.Labels)(v)
+}
+
+func (v *labelsValue) String() string {
+	return (*profile.Labels)(v).String()
+}
+
+func (v *labelsValue) Set(s string) error {
+	var labels profile.Labels
+	if err := labels.FromString(s); err != nil {
+		return err
+	}
+	*v = labelsValue(labels)
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/profefe/profefe/pkg/agentutil"
 	"github.com/profefe/profefe/pkg/log"
 )
 
@@ -20,6 +21,7 @@ type Config struct {
 	Addr        string
 	ExitTimeout time.Duration
 	Logger      log.Config
+	AgentConfig agentutil.Config
 	Badger      BadgerConfig
 	S3          S3Config
 }
@@ -29,6 +31,8 @@ func (conf *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&conf.ExitTimeout, "exit-timeout", defaultExitTimeout, "server shutdown timeout")
 
 	conf.Logger.RegisterFlags(f)
+	conf.AgentConfig.RegisterFlags(f)
+
 	conf.Badger.RegisterFlags(f)
 	conf.S3.RegisterFlags(f)
 }

--- a/pkg/profile/labels.go
+++ b/pkg/profile/labels.go
@@ -175,6 +175,9 @@ func (labels Labels) EncodeTo(w LabelsEncoder) {
 }
 
 func (labels Labels) String() string {
+	if labels == nil {
+		return ""
+	}
 	var buf bytes.Buffer
 	labels.EncodeTo(&buf)
 	return buf.String()


### PR DESCRIPTION
Add a set of flags to configure agent to read profiling data and send the data to collector's public address. That is

```
$ profefe -addr='localhost:10100' -badger.dir=data \
  -profefe.agent.collector-addr='http://localhost:10100' \
  -profefe.agent.service-name='profefe-collector' \
  -profefe.agent.labels='region=eu,dc=ber,host=localhost' \
  -profefe.agent.read-interval=1m \
  -profefe.agent.enable-cpu-profile=10s \
  -profefe.agent.enable-heap-profile
```