### PR TITLE
Fix typo in ClickHouse storage schema

### DIFF
--- a/pkg/storage/clickhouse/schema/profefe.sql
+++ b/pkg/storage/clickhouse/schema/profefe.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS pprof_samples (
         file_name LowCardinality(String),
         lineno UInt16
     ),
-    values Array(UInt64),
+    values Array(Int64),
     values_type Array(LowCardinality(String)),
     values_unit Array(LowCardinality(String)),
     labels Nested (


### PR DESCRIPTION
Refer to https://github.com/google/pprof/blob/master/proto/profile.proto

Sample's values are `repeated int64 value`