### PR TITLE
Call query API with out "type" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ curl -XPOST \
   --data-binary "@$HOME/pprof/api-backend-trace.out"
 ```
 
-### Query saved meta information
+### Query meta information about stored profiles
 
 ```
 GET /api/0/profiles?service=<service>&type=<type>&from=<created_from>&to=<created_to>&labels=<key=value,key=value>
@@ -190,9 +190,9 @@ GET /api/0/profiles?service=<service>&type=<type>&from=<created_from>&to=<create
 ```
 
 - `service` — service name
-- `type` — profile type ("cpu", "heap", "block", "mutex", "goroutine", "threadcreate", "trace", "other")
-- `created_from`, `created_to` — a time window between which profiling data was collected, e.g. "from=2006-01-02T15:04:05"
-- `labels` — a set of key-value pairs
+- `from`, `to` — a time frame in which profiling data was collected, e.g. "from=2006-01-02T15:04:05"
+- `type` — profile type ("cpu", "heap", "block", "mutex", "goroutine", "threadcreate", "trace", "other") (Optional)
+- `labels` — a set of key-value pairs, e.g. "region=europe-west3,dc=fra,ip=1.2.3.4,version=1.0" (Optional)
 
 **Example**
 
@@ -211,9 +211,9 @@ GET /api/0/profiles/merge?service=<service>&type=<type>&from=<created_from>&to=<
 
 Request parameters are the same as for querying meta information.
 
-*Note, merging runtime traces is not supported.*
+*Note, "type" parameter is required; merging runtime traces is not supported.*
 
-### Return individual profiling data
+### Return individual profile as pprof-formatted data
 
 ```
 GET /api/0/profiles/<id>
@@ -235,7 +235,7 @@ GET /api/0/profiles/<id1>+<id2>+...
 
 - `id1`, `id2` - ids of stored profiles
 
-*Note, merging is possible only for profiles of the same type.*
+*Note, merging is possible only for profiles of the same type; merging runtime traces is not supported.*
 
 ### Get services for which profiling data is stored
 

--- a/pkg/profefe/profiles_handler.go
+++ b/pkg/profefe/profiles_handler.go
@@ -132,8 +132,9 @@ func (h *ProfilesHandler) HandleMergeProfiles(w http.ResponseWriter, r *http.Req
 		return err
 	}
 
-	if params.Type == profile.TypeTrace {
-		return StatusError(http.StatusMethodNotAllowed, "tracing profiles are not mergeable", nil)
+	switch params.Type {
+	case profile.TypeUnknown, profile.TypeTrace:
+		return StatusError(http.StatusMethodNotAllowed, fmt.Sprintf("can't merge profiles of %v type", params.Type), nil)
 	}
 
 	w.Header().Set("Content-Type", "application/octet-stream")

--- a/pkg/profefe/request.go
+++ b/pkg/profefe/request.go
@@ -29,9 +29,7 @@ func parseProfileParams(q url.Values) (service string, ptype profile.ProfileType
 		service = v
 	}
 
-	if v := q.Get("type"); v == "" {
-		return "", profile.TypeUnknown, nil, fmt.Errorf("missing \"type\"")
-	} else if err := ptype.FromString(v); err != nil {
+	if err := ptype.FromString(q.Get("type")); err != nil {
 		return "", profile.TypeUnknown, nil, fmt.Errorf("bad \"type\" %q: %s", q.Get("type"), err)
 	}
 

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -21,7 +21,7 @@ func JoinIDs(ids ...ID) (string, error) {
 		}
 		sid := string(id)
 		if strings.ContainsRune(sid, '+') {
-			return "", fmt.Errorf("could not join %v: found recerved char in %q", ids, id)
+			return "", fmt.Errorf("could not join %v: reserved char in %q", ids, id)
 		}
 		buf.WriteString(sid)
 	}
@@ -36,7 +36,7 @@ func SplitIDs(s string) ([]ID, error) {
 	ids := make([]ID, len(ss))
 	for i, sid := range ss {
 		if sid == "" {
-			return nil, fmt.Errorf("could not split %q: found empty id at %d", s, i)
+			return nil, fmt.Errorf("could not split %q: empty id at %d", s, i)
 		}
 		ids[i] = ID(sid)
 	}

--- a/pkg/storage/clickhouse/reader.go
+++ b/pkg/storage/clickhouse/reader.go
@@ -197,7 +197,7 @@ func buildSQLSelectProfiles(columns []string, params *storage.FindProfilesParams
 	if len(whereClause) > 0 {
 		conds = append(conds, "AND "+strings.Join(whereClause, " AND "))
 	}
-	conds = append(conds, "ORDER BY created_at")
+	conds = append(conds, "ORDER BY created_at, profile_type")
 	if params.Limit > 0 {
 		conds = append(conds, fmt.Sprintf("LIMIT %d", params.Limit))
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -69,9 +69,6 @@ func (params *FindProfilesParams) Validate() error {
 	if params.Service == "" {
 		return errors.New("empty service")
 	}
-	if params.Type == profile.TypeUnknown {
-		return errors.New("unknown profile type")
-	}
 	if params.CreatedAtMin.IsZero() || params.CreatedAtMax.IsZero() {
 		return fmt.Errorf("zero timestamp: CreatedAtMin %v, CreatedAtMax %v", params.CreatedAtMin, params.CreatedAtMax)
 	}


### PR DESCRIPTION
closes #99 

```
› curl -s 'http://localhost:10100/api/0/profiles?service=refresh_worker&from=2020-06-08T00:00:00&to=2020-06-08T23:59:00&limit=2' | jq -c '.body | .[].type'
"cpu"
"heap"
```