### PR TITLE
Update docker image to Go 1.15.2

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.1-alpine3.12 as builder
+FROM golang:1.15.2-alpine3.12 as builder
 
 RUN apk add --update --no-cache build-base
 


### PR DESCRIPTION
1.15.2 has [a good bunch of fixes][1] in runtime and compiler. So guess it's worth bumping the version once again.

[1]: https://github.com/golang/go/issues?q=milestone%3AGo1.15.2+label%3ACherryPickApproved