### PR TITLE
testing: specify clickhouse version in docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         - MINIO_ENDPOINT_URL=http://127.0.0.1:19000
         - CLICKHOUSE_DSN='tcp://127.0.0.1:29000'
       install:
-        - docker-compose up -V -d minio clickhouse
+        - docker-compose up -d --renew-anon-volumes --remove-orphans minio clickhouse
       script: make test TESTFLAGS=-v
 
     - stage: code check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       MINIO_SECRET_KEY: minioadmin123
 
   clickhouse:
-    image: yandex/clickhouse-server
+    image: yandex/clickhouse-server:20.8
     ports:
       - 127.0.0.1:28123:8123
       - 127.0.0.1:29000:9000


### PR DESCRIPTION
As it was raised in #119 tests for `storage/clickhouse` fail for ClickHouse server newer than 20.8. I'd like to specify the known working version for now to make the tests pass and will look into the changes in CH later.